### PR TITLE
Make main wallet address on dashboard clearer

### DIFF
--- a/index.php
+++ b/index.php
@@ -73,7 +73,7 @@ if ($currentWallet == NavCoin){
 <div class="well">
 <div class="row">
 	<div class="col-lg-7">
-	<p> Your main wallet address is <?php print_r($address); ?>.
+	<p> Your main wallet address is: <input type="text" name="main_wallet_address" value="<?php print_r($address); ?>" disabled readonly />
 	<p>The network is currently on block <?php print_r($coin->getblockcount()); ?>.
 	<?php if ($currentWallet == NavCoin): ?>
 		<?php echo "<p><b>Stake report</b></p><p>Last 24h: {$stakereport['Last 24H']} NAV</p><p>Last 7d: {$stakereport['Last 7 Days']} NAV</p><p>Last 30d: {$stakereport['Last 30 Days']} NAV</p><p>Last 365d: {$stakereport['Last 365 Days']} NAV</p>" ?>

--- a/index.php
+++ b/index.php
@@ -73,7 +73,7 @@ if ($currentWallet == NavCoin){
 <div class="well">
 <div class="row">
 	<div class="col-lg-7">
-	<p> Your main wallet address is: <input type="text" name="main_wallet_address" value="<?php print_r($address); ?>" size="48" disabled readonly />
+	<p> Your main wallet address is: <input type="text" name="main_wallet_address" value="<?php print_r($address); ?>" size="48" readonly />
 	<p>The network is currently on block <?php print_r($coin->getblockcount()); ?>.
 	<?php if ($currentWallet == NavCoin): ?>
 		<?php echo "<p><b>Stake report</b></p><p>Last 24h: {$stakereport['Last 24H']} NAV</p><p>Last 7d: {$stakereport['Last 7 Days']} NAV</p><p>Last 30d: {$stakereport['Last 30 Days']} NAV</p><p>Last 365d: {$stakereport['Last 365 Days']} NAV</p>" ?>

--- a/index.php
+++ b/index.php
@@ -73,7 +73,7 @@ if ($currentWallet == NavCoin){
 <div class="well">
 <div class="row">
 	<div class="col-lg-7">
-	<p> Your main wallet address is: <input type="text" name="main_wallet_address" value="<?php print_r($address); ?>" size="48" readonly />
+	<p> Your main wallet address is: <input type="text" name="main_wallet_address" value="<?php print_r($address); ?>" onClick="this.setSelectionRange(0, this.value.length);" size="48" readonly />
 	<p>The network is currently on block <?php print_r($coin->getblockcount()); ?>.
 	<?php if ($currentWallet == NavCoin): ?>
 		<?php echo "<p><b>Stake report</b></p><p>Last 24h: {$stakereport['Last 24H']} NAV</p><p>Last 7d: {$stakereport['Last 7 Days']} NAV</p><p>Last 30d: {$stakereport['Last 30 Days']} NAV</p><p>Last 365d: {$stakereport['Last 365 Days']} NAV</p>" ?>

--- a/index.php
+++ b/index.php
@@ -73,7 +73,7 @@ if ($currentWallet == NavCoin){
 <div class="well">
 <div class="row">
 	<div class="col-lg-7">
-	<p> Your main wallet address is: <input type="text" name="main_wallet_address" value="<?php print_r($address); ?>" disabled readonly />
+	<p> Your main wallet address is: <input type="text" name="main_wallet_address" value="<?php print_r($address); ?>" size="36" disabled readonly />
 	<p>The network is currently on block <?php print_r($coin->getblockcount()); ?>.
 	<?php if ($currentWallet == NavCoin): ?>
 		<?php echo "<p><b>Stake report</b></p><p>Last 24h: {$stakereport['Last 24H']} NAV</p><p>Last 7d: {$stakereport['Last 7 Days']} NAV</p><p>Last 30d: {$stakereport['Last 30 Days']} NAV</p><p>Last 365d: {$stakereport['Last 365 Days']} NAV</p>" ?>

--- a/index.php
+++ b/index.php
@@ -73,7 +73,7 @@ if ($currentWallet == NavCoin){
 <div class="well">
 <div class="row">
 	<div class="col-lg-7">
-	<p> Your main wallet address is: <input type="text" name="main_wallet_address" value="<?php print_r($address); ?>" size="36" disabled readonly />
+	<p> Your main wallet address is: <input type="text" name="main_wallet_address" value="<?php print_r($address); ?>" size="48" disabled readonly />
 	<p>The network is currently on block <?php print_r($coin->getblockcount()); ?>.
 	<?php if ($currentWallet == NavCoin): ?>
 		<?php echo "<p><b>Stake report</b></p><p>Last 24h: {$stakereport['Last 24H']} NAV</p><p>Last 7d: {$stakereport['Last 7 Days']} NAV</p><p>Last 30d: {$stakereport['Last 30 Days']} NAV</p><p>Last 365d: {$stakereport['Last 365 Days']} NAV</p>" ?>


### PR DESCRIPTION
Move the main wallet address on the dashboard into a read-only input field that selects its contents on click to make things clearer and easier, fixes #7.