### PR TITLE
Store logincheck in the session data

### DIFF
--- a/pass.php
+++ b/pass.php
@@ -4,10 +4,10 @@ $encryptedpasswd= getpass() ;
 $showlogin = true ;
 // check cookie 
 
-if (isset($_COOKIE['logincheck'])) 
+if (isset($_SESSION['logincheck'])) 
 {
 
-	if (md5($encryptedpasswd) == $_COOKIE['logincheck'])
+	if (md5($encryptedpasswd) == $_SESSION['logincheck'])
 	{
 	$showlogin = false ;
 	}
@@ -23,7 +23,7 @@ if (isset($_POST['pass']) )
 	else
 	{
 	$showlogin= false; // the pass is good
-	setcookie("logincheck",md5($encryptedpasswd),time()+3600);// expire in 1 hour
+	$_SESSION['logincheck'] = md5($encryptedpasswd);
 	}
 }
 else


### PR DESCRIPTION
The `logincheck` cookie is sticky and persists through server restart and PHP cookie purge. Rolling the field as a component of `$_SESSION` in order to allow the operator to force logout by removing sessions and not to send the password hash around every request (should be safe, but why do it if session serves the same purpose and is furthermore ephemeral).

Note: I'm not a web-dev, just something I ran into. Pls review.