### PR TITLE
GUI for interacting with the community fund via NavPi

### DIFF
--- a/control.php
+++ b/control.php
@@ -17,6 +17,7 @@ include ("pass.php");
             <a href="allcommands" class='btn btn-default' role='button'>All Commands</a>
             <a href="setpass" class='btn btn-default' role='button'>Change UI Password</a>
             <a href="fixorphans" class='btn btn-default' role='button'>Fix Orphans</a>
+            <a href="getcommunityfundinfo" class='btn btn-default' role='button'>Community Fund Infos</a>
          </div><!-- /.row -->
       </div><!-- /.padding -->
       <div style="padding: 5px 15px 5px;">

--- a/css/main.css
+++ b/css/main.css
@@ -125,6 +125,9 @@ a:focus {
 .table-bordered > tfoot > tr > td {
   border: 1px solid #CCC;
 }
+.table-bordered > thead > tr >td.valignmiddle {
+  vertical-align: middle;
+}
 .table-hover > tbody > tr:hover {
   color: #333;
   background-color: #f5f5f5;

--- a/getcommunityfundinfo.php
+++ b/getcommunityfundinfo.php
@@ -33,7 +33,7 @@ include ("pass.php");
                 // with the json, we could loop over the yes-votes, no-votes, non-votes separately and don't have to check them
                 foreach ($communityfundinfos['votingPeriod']['votedProposals'] as $row) {
                   $desc = $row['str'];
-                  $amount = $row['amount'] * 0.00000001;
+                  $amount = $row['amount'];
                   $hash = $row['hash'];
 
                   $isYesVote = array_filter($proposalYesVotes, function($var) use ($hash) { return preg_match("/\b$hash\b/i", $var); });

--- a/getcommunityfundinfo.php
+++ b/getcommunityfundinfo.php
@@ -1,0 +1,133 @@
+
+<?php
+include ("header.php");
+include ("pass.php");
+        $communityfundinfos = $coin->cfundstats();
+        $proposalvotelist = $coin->proposalvotelist();
+        $proposalYesVotes = $proposalvotelist['yes'];
+        $proposalNoVotes = $proposalvotelist['no'];
+        $proposalNotVoted = $proposalvotelist['null'];
+        $paymentrequestvotelist = $coin->paymentrequestvotelist();
+        $paymentRequestYesVotes = $paymentrequestvotelist['yes'];
+        $paymentRequestNoVotes = $paymentrequestvotelist['no'];
+        $paymentRequestNotVoted = $paymentrequestvotelist['null'];
+
+?>
+
+<p><b>Community Fund Infos</b></p>
+<p>Currently voted on proposals</p>
+<div class="panel panel-default">
+  <div class="table-responsive">
+    <?php
+      echo "<table class='table-hover table-condensed table-bordered table'>
+              <thead>
+                <tr>
+                  <th>Description</th>
+                  <th>Amount</th>
+                  <th>Your vote</th>
+                  <th>Vote</th>
+                </tr>";
+
+                // at the moment, proposalvotelist() returns a string which would have to be parsed
+                // it's easier to loop over the result of cfundstats until proposalvotelist returns a json object
+                // with the json, we could loop over the yes-votes, no-votes, non-votes separately and don't have to check them
+                foreach ($communityfundinfos['votingPeriod']['votedProposals'] as $row) {
+                  $desc = $row['str'];
+                  $amount = $row['amount'] * 0.00000001;
+                  $hash = $row['hash'];
+
+                  $isYesVote = array_filter($proposalYesVotes, function($var) use ($hash) { return preg_match("/\b$hash\b/i", $var); });
+                  $isNoVote = array_filter($proposalNoVotes, function($var) use ($hash) { return preg_match("/\b$hash\b/i", $var); });
+                  $isNotVoted = array_filter($proposalNotVoted, function($var) use ($hash) { return preg_match("/\b$hash\b/i", $var); });
+                  $yourVote = (!empty($isYesVote) ? "Yes" : (!empty($isNoVote) ? "No" : "Not Voted"));
+
+                  echo "<tr>
+                          <td class='valignmiddle' style='width:70%'>{$desc}</td>
+                          <td class='valignmiddle'>{$amount}</td>
+                          <td class='valignmiddle'>{$yourVote}</td>
+                          <td class='valignmiddle'>
+                            <div class='input-group'>
+                              <span class='input-group-btn'>
+                                <form action='command' method='POST'>
+                                  <button style='float:left' class='btn btn-default' type='submit' value='command'>Yes</button>
+                                  <input type='hidden' name='order' value='proposalvote' />
+                                  <input type='hidden' name='var1' value='{$hash}' />
+                                  <input type='hidden' name='var2' value='yes' />
+                                </form>
+
+                                <form action='command' method='POST'><input type='hidden'>
+                                  <button class='btn btn-default' type='submit' value='command'>No</button>
+                                  <input type='hidden' name='order' value='proposalvote' />
+                                  <input type='hidden' name='var1' value='{$hash}' />
+                                  <input type='hidden' name='var2' value='no' />
+                                </form>
+                              </span>
+                            </div>
+                          </td>
+                        </tr>";
+                } //endforeach
+                echo "</table>";
+    ?>
+  </div>
+</div>
+
+
+<p>Currently voted on payment requests</p>
+<div class="panel panel-default">
+  <div class="table-responsive">
+    <?php
+      echo "<table class='table-hover table-condensed table-bordered table'>
+              <thead>
+                <tr>
+                  <th>Proposal Description</th>
+                  <th>Payment Request Description</th>
+                  <th>Amount</th>
+                  <th>Your vote</th>
+                  <th>Vote</th>
+                </tr>";
+
+                // at the moment, paymentrequestvotelist() returns a string which would have to be parsed
+                // it's easier to loop over the result of cfundstats until proposalvotelist returns a json object
+                // with the json, we could loop over the yes-votes, no-votes, non-votes separately and don't have to check them
+                foreach ($communityfundinfos['votingPeriod']['votedPaymentrequests'] as $row) {
+                  $proposalDesc = $row['proposalDesc'];
+                  $paymentRequestDesc = $row['desc'];
+                  $amount = $row['amount'];
+                  $hash = $row['hash'];
+                  $isYesVote = array_filter($paymentRequestYesVotes, function($var) use ($hash) { return preg_match("/\b$hash\b/i", $var); });
+                  $isNoVote = array_filter($paymentRequestNoVotes, function($var) use ($hash) { return preg_match("/\b$hash\b/i", $var); });
+                  $isNotVoted = array_filter($paymentRequestNotVoted, function($var) use ($hash) { return preg_match("/\b$hash\b/i", $var); });
+                  $yourVote = (!empty($isYesVote) ? "Yes" : (!empty($isNoVote) ? "No" : "Not Voted"));
+
+                  echo "<tr>
+                          <td class='valignmiddle' style='width:35%'>{$proposalDesc}</td>
+                          <td class='valignmiddle' style='width:35%'>{$paymentRequestDesc}</td>
+                          <td class='valignmiddle'>{$amount}</td>
+                          <td class='valignmiddle'>{$yourVote}</td>
+                          <td class='valignmiddle'>
+                            <div class='input-group'>
+                              <span class='input-group-btn'>
+                                <form action='command' method='POST'><input type='hidden'>
+                                  <button style='float:left' class='btn btn-default' type='submit' value='command'>Yes</button>
+                                  <input type='hidden' name='order' value='paymentrequestvote' />
+                                  <input type='hidden' name='var1' value='{$hash}' />
+                                  <input type='hidden' name='var2' value='yes' />
+                                </form>
+
+                                <form action='command' method='POST'>
+                                  <button class='btn btn-default' type='submit' value='command'>No</button>
+                                  <input type='hidden' name='order' value='paymentrequestvote' />
+                                  <input type='hidden' name='var1' value='{$hash}' />
+                                  <input type='hidden' name='var2' value='no' />
+                                </form>
+                              </span>
+                            </div>
+                          </td>
+                        </tr>";
+                  } //endforeach
+                  echo "</table>";
+      ?>
+    </div>
+  </div>
+</div>
+<?php include ("footer.php"); ?>

--- a/getcommunityfundinfo.php
+++ b/getcommunityfundinfo.php
@@ -87,7 +87,7 @@ include ("pass.php");
                 </tr>";
 
                 // at the moment, paymentrequestvotelist() returns a string which would have to be parsed
-                // it's easier to loop over the result of cfundstats until proposalvotelist returns a json object
+                // it's easier to loop over the result of cfundstats until paymentrequestvotelist returns a json object
                 // with the json, we could loop over the yes-votes, no-votes, non-votes separately and don't have to check them
                 foreach ($communityfundinfos['votingPeriod']['votedPaymentrequests'] as $row) {
                   $proposalDesc = $row['proposalDesc'];


### PR DESCRIPTION
This feature branch implements a graphical user interface for interacting with community fund proposals and payment requests in the NavPi.

The UI can be found via "Control -> Community Fund Infos".
The CF info page has two tables:
- the first table shows all currently voted on proposals. For each proposal it's possible to see your own vote. You can also vote for or against a proposal via buttons.
- the second table shows all currently voted on payment requests. For each payment request it's possible to see your own vote. You can also vote for or against a payment request via buttons.